### PR TITLE
Adds a --fetch option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'octokit'

--- a/lib/formula_loader.rb
+++ b/lib/formula_loader.rb
@@ -1,16 +1,18 @@
 module Homebrew
   class FormulaLoader
-    def self.load_formulas(name)
+    def self.load_formulas(name, recurse = false)
       formula = Formulary.factory(name)
-      result = [formula.name]
-      result += get_deps(formula, [])
+      result = [{name: formula.name, homepage: formula.homepage}]
+      if recurse
+        result += get_deps(formula, [])
+      end
       result
     end
 
     private_class_method def self.get_deps(formula, result = [])
       formula.deps.each do |dependency|
         dep = Formulary.factory(dependency.name)
-        result << dep.name
+        result << {name: dep.name, homepage: dep.homepage}
         get_deps(dep, result)
       end
       result


### PR DESCRIPTION
## Summary

This option attempts to to 'license' to pull license info from the Github License API if possible. If the formula's homepage isn't a GitHub repo, then just display the homepage URL so that the user can search for licensing information themselves.

## Rationale

When trying to find licensing information for a formula, it is toilsome to run `brew info <formula>` and then manually visit the homepage URL and find licensing information. This leans on the Github License API to pull the licensing information if and only if the formula's homepage is a GitHub repository.

## How did you test this?

I tested this in the `zachwick/licensewip` tap because I don't think there's a way to pass a repository branch identifier when invoking `brew tap`.