### PR TITLE
Fixes the handling of too many options being passed

### DIFF
--- a/cmd/brew-license.rb
+++ b/cmd/brew-license.rb
@@ -76,6 +76,12 @@ show_usage = <<EOS
 #{usage}
 EOS
 
+too_many_flags = <<EOS
+The -r and -f options are mutually exclusive.
+
+#{usage}
+EOS
+
 options = {}
 OptionParser.new do |opts|
   options[:search] = 0


### PR DESCRIPTION
## Summary
The `-r` and `-f` flags are meant to be mutually exclusive, so make sure that passing both results in a meaningful output response.

## Rationale
`-r` and `-f` (`--recurse` and `--fetch` respectively) are meant to be mutually exclusive, mostly because if we are attempting to fetch every dependency in the formula's dependency tree, we may very easily hit the GitHub API rate limit.

## How did you test this?
Tested on the zachwick/licensewip tap.