### PR TITLE
Pick one way to write license in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ External command for showing the license(s) the given formulae are available und
 # Usage
 The most useful way to use the command is by invoking
 
-    $ brew licence formula1
+    $ brew license formula1
 
 which will print out any known licensing info for that formula.
 
 ```
-brew licence formula1
+brew license formula1
 brew license formula1 formula2 ...
-brew licence [-r|--recurse] formula1
+brew license [-r|--recurse] formula1
 brew license [-f|--fetch] formula1
 brew license [-h|--help]
 


### PR DESCRIPTION
Used the US grammar to keep it easy.
https://www.grammarly.com/blog/licence-license/