### PR TITLE
Check formula's URL for GH repo too

### DIFF
--- a/cmd/brew-license.rb
+++ b/cmd/brew-license.rb
@@ -116,7 +116,7 @@ elsif  options[:search] == 1
 else
   candidates = []
   ARGV.each do |candidate|
-    candidates += [{name: candidate, homepage: ''}]
+    candidates += [{name: candidate, homepage: '', url: ''}]
   end
 end
 
@@ -127,12 +127,20 @@ candidates.each do |candidate|
     # 2. If it is, attempt to use the Licenses API
     # puts("#{candidate[:name]}: #{candidate[:homepage]}")
     homepage = candidate[:homepage]
+    url = candidate[:url]
     if homepage.include? 'github.com'
       hp_parts = homepage.split('/')
 
       github_client = Octokit::Client.new()
 
       license = github_client.repository_license_contents "#{hp_parts[hp_parts.length - 2]}/#{hp_parts[hp_parts.length - 1]}", :accept => 'application/vnd.github.json'
+      puts "#{candidate[:name]}: \"#{license['license']['spdx_id']}\""
+    elsif url.include? 'github.com'
+      url_parts = url.split('/')
+
+      github_client = Octokit::Client.new()
+
+      license = github_client.repository_license_contents "#{url_parts[3]}/#{url_parts[4]}", :accept => 'application/vnd.github.json'
       puts "#{candidate[:name]}: \"#{license['license']['spdx_id']}\""
     else
       puts "#{candidate[:name]}'s homepage is not a Github repo so we can't fetch license info.\nVisit #{candidate[:homepage]} to find licensing info."

--- a/lib/formula_loader.rb
+++ b/lib/formula_loader.rb
@@ -2,7 +2,7 @@ module Homebrew
   class FormulaLoader
     def self.load_formulas(name, recurse = false)
       formula = Formulary.factory(name)
-      result = [{name: formula.name, homepage: formula.homepage}]
+      result = [{name: formula.name, homepage: formula.homepage, url: formula.stable.url}]
       if recurse
         result += get_deps(formula, [])
       end
@@ -12,7 +12,7 @@ module Homebrew
     private_class_method def self.get_deps(formula, result = [])
       formula.deps.each do |dependency|
         dep = Formulary.factory(dependency.name)
-        result << {name: dep.name, homepage: dep.homepage}
+        result << {name: dep.name, homepage: dep.homepage, url: dep.stable.url}
         get_deps(dep, result)
       end
       result

--- a/scripts/fetch-license.rb
+++ b/scripts/fetch-license.rb
@@ -9,6 +9,7 @@ client = Octokit::Client.new(:access_token => ARGV[0])
 info.each do |formula|
     name = formula['name']
     homepage = formula['homepage']
+    url = formula['stable']['url']
     
     if !(homepage.nil?) && (homepage.include? 'github.com')
         hp_parts = homepage.split('/')
@@ -18,7 +19,16 @@ info.each do |formula|
             puts "\"#{name}\": \"#{license['license']['spdx_id']}\","
         rescue
             puts "\"#{name}\": \"\","
-        end 
+        end
+    elsif !(url.nil?) && (url.include? 'github.com')
+        url_parts = url.split('/')
+
+        begin
+            license = client.repository_license_contents "#{url_parts[3]}/#{url_parts[4]}", :accept => 'application/vnd.github.json'
+            puts "\"#{name}\": \"#{license['license']['spdx_id']}\","
+        rescue
+            puts "\"#{name}\": \"\","
+        end
     else
         puts "\"#{name}\": \"\","
     end


### PR DESCRIPTION
 - Some formula like OpenCoarrays have Homepages with custom domains,
   but still host code on GitHub.

# Is this a feature or bugfix PR?

yes: feature

## Summary

Some formula have code hosted on GitHub, but have homepages with custom domain names or hosted by some other service. This PR will also examine the `formula['stable']['url']` to see if it points to `https://github.com/<user-or-org>/<repo>/....` and fetch the user/org and repo so that Github's API can be queried for a license

## Rationale

Homepages may be different than repository landing pages on GitHub for code that is hosted on GH

## How did you test this?

I tested that it works with a tap (the incoming PR) where I merged it on my fork's master branch. I tested it with, e.g.,

`brew license -f opencoarrays`

which was not returning anything before this PR.

## Caveats:

- I was unsure of how to use the stuff in the `scripts/` dir, so I updated it, but it is untested
- There is probably more code replication due to `if ... elsif ... ` blocks with some shared content. I'm relatively new to Ruby, and didn't have much time to contribute so I didn't make further efforts to reduce repetition and verbosity.