### PR TITLE
Add asdf license

### DIFF
--- a/cmd/licenses.json
+++ b/cmd/licenses.json
@@ -180,7 +180,7 @@
   "asciinema": "",
   "asciiquarium": "",
   "asciitex": "",
-  "asdf": "",
+  "asdf": "MIT",
   "asio": "",
   "ask-cli": "",
   "asn1c": "",


### PR DESCRIPTION
# Is this a licensing information PR?

If this is a PR that is adding licensing information for formula, then please make sure that your PR is only adding or editing a single formula's licensing information. If possible, a link to where you found the formula's licensing information would be good to include for tracking purposes.

Please note that you must use the use only (SPDX identifiers)[https://spdx.org/licenses/]

## Formula Name

asdf

## License

MIT

## License URL (optional)

https://github.com/asdf-vm/asdf/blob/master/LICENSE

# Is this a feature or bugfix PR?

## Summary

## Rationale

## How did you test this?