### PR TITLE
Fix markdown in pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 If this is a PR that is adding licensing information for formula, then please make sure that your PR is only adding or editing a single formula's licensing information. If possible, a link to where you found the formula's licensing information would be good to include for tracking purposes.
 
-Please note that you must use the use only (SPDX identifiers)[https://spdx.org/licenses/]
+Please note that you must use the use only [SPDX identifiers](https://spdx.org/licenses/)
 
 ## Formula Name
 


### PR DESCRIPTION
Markdown link syntax was swapped. This fix parenthesis typo.