### PR TITLE
Add license for ant-contrib

### DIFF
--- a/cmd/licenses.json
+++ b/cmd/licenses.json
@@ -98,7 +98,7 @@
   "ansifilter": "",
   "ansiweather": "BSD-2-Clause",
   "ant": "Apache-2.0",
-  "ant-contrib": "",
+  "ant-contrib": "Apache-1.1",
   "ant@1.9": "",
   "antigen": "",
   "antiword": "",


### PR DESCRIPTION
## Formula Name

ant-contrib

## License

Apache-1.1

## License URL

https://sourceforge.net/p/ant-contrib/code/HEAD/tree/ant-contrib/trunk/docs/LICENSE.txt