### PR TITLE
Add license for cassandra

### DIFF
--- a/cmd/licenses.json
+++ b/cmd/licenses.json
@@ -483,7 +483,7 @@
   "carthage": "MIT",
   "cash-cli": "MIT",
   "cask": "GPL-3.0-only",
-  "cassandra": "",
+  "cassandra": "Apache-2.0",
   "cassandra@2.1": "",
   "cassandra@2.2": "",
   "castxml": "Apache-2.0",


### PR DESCRIPTION
## Formula Name

cassandra

## License

Apache-2.0

## License URL

https://gitbox.apache.org/repos/asf?p=cassandra.git;a=blob;f=LICENSE.txt;h=d5c4984908ede433c7f32084e9d7642af0866b84;hb=HEAD
