### PR TITLE
Add license for daemon

### DIFF
--- a/cmd/licenses.json
+++ b/cmd/licenses.json
@@ -780,7 +780,7 @@
   "cxxtest": "",
   "cython": "Apache-2.0",
   "czmq": "",
-  "daemon": "",
+  "daemon": "GPL-2.0-or-later",
   "daemonize": "",
   "daemonlogger": "",
   "daemontools": "",


### PR DESCRIPTION
## Formula Name

daemon

## License

GPL-2.0-or-later

## License URL

http://libslack.org/daemon/ - mentions GPL with no version, but source contains v2
