### PR TITLE
Add license for gcal

### DIFF
--- a/cmd/licenses.json
+++ b/cmd/licenses.json
@@ -1341,7 +1341,7 @@
   "gawk": "GPL-3.0-only",
   "gbdfed": "",
   "gcab": "",
-  "gcal": "",
+  "gcal": "GFDL-1.3-only",
   "gcc": "GPL-3.0-only",
   "gcc@4.9": "",
   "gcc@5": "",


### PR DESCRIPTION
## Formula Name

gcal

## License

GPL-1.0-or-later

## License URL

https://www.gnu.org/software/gcal/manual/html_node/GNU-Free-Documentation-License.html#GNU-Free-Documentation-License
