### PR TITLE
License information for „getdns“

### DIFF
--- a/cmd/licenses.json
+++ b/cmd/licenses.json
@@ -1394,7 +1394,7 @@
   "gerrit-tools": "",
   "get-flash-videos": "Apache-2.0",
   "get_iplayer": "GPL-3.0-only",
-  "getdns": "",
+  "getdns": "BSD-3-Clause",
   "getmail": "",
   "gettext": "GPL-3.0-only",
   "getxbook": "",


### PR DESCRIPTION
Formula Name: getdns
License: SPDX short identifier: BSD-3-Clause
License URL (optional): https://opensource.org/licenses/BSD-3-Clause
Source: https://getdnsapi.net/