### PR TITLE
License information for „armadillo“

### DIFF
--- a/cmd/licenses.json
+++ b/cmd/licenses.json
@@ -1394,7 +1394,7 @@
   "gerrit-tools": "",
   "get-flash-videos": "Apache-2.0",
   "get_iplayer": "GPL-3.0-only",
-  "getdns": "",
+  "getdns": "BSD-3-Clause",
   "getmail": "",
   "gettext": "GPL-3.0-only",
   "getxbook": "",

--- a/cmd/licenses.json
+++ b/cmd/licenses.json
@@ -193,7 +193,7 @@
   "astyle": "",
   "at-spi2-atk": "",
   "at-spi2-core": "",
-  "atari800": "",
+  "atari800": "GPL-2.0-only",
   "atdtool": "BSD-3-Clause",
   "aterm": "",
   "atf": "",

--- a/cmd/licenses.json
+++ b/cmd/licenses.json
@@ -162,7 +162,7 @@
   "aria2": "GPL-2.0-or-later",
   "ark": "Apache-2.0",
   "arm-linux-gnueabihf-binutils": "",
-  "armadillo": "",
+  "armadillo": "Apache-2.0",
   "armor": "MIT",
   "arp-scan": "GPL-3.0-only",
   "arp-sk": "",


### PR DESCRIPTION
License information for „armadillo“

License: https://opensource.org/licenses/Apache-2.0
Source: http://arma.sourceforge.net/license.html